### PR TITLE
Implemented inspection reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,45 @@
 # stylelint-teamcity-reporter
 
-Outputs stylelint results compatible with [TeamCity](https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests).
+Outputs [stylelint](https://stylelint.io) results compatible with [TeamCity](https://confluence.jetbrains.com/display/TCD10/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests).
 
 ## Usage
 
 Install from npm:
 
 ```
-npm install stylelint-teamcity-reporter
+npm install --save-dev stylelint-teamcity-reporter
+```
+
+or Yarn:
+
+```
+yarn add -D stylelint-teamcity-reporter
 ```
 
 Then, set stylelint's custom formatter to the package. To do this from CLI, use:
 
 ```
 stylelint \"**/*.css\" --custom-formatter=node_modules/stylelint-teamcity-reporter
+```
+
+## Configuration
+
+Without any configuration, stylelint results will be reported as tests on a TeamCity build (`"reporter": "errors"`). You can also configure it to produce code inspection-style output (`"reporter": "inspections"`), which is displayed on the "Code Inspections" tab in TeamCity.
+Settings are looked for in the following priority:
+
+#### 1. From your package.json
+If you have a package.json file in the current directory, you can add an extra "stylelint-teamcity-reporter" property to it:
+
+```json
+{
+  "stylelint-teamcity-reporter": {
+    "reporter": "inspections"
+  }
+}
+```
+
+#### 2. ENV variables
+
+```sh
+export STYLELINT_TEAMCITY_REPORTER="inspections"
 ```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 module.exports = (stylelintResults) => {
   function tcEscape(message) {
+    if(!message.replace) {
+      return message;
+    }
     return message
       .replace("'", "|'")
       .replace("\n", "|n")
@@ -21,27 +24,122 @@ module.exports = (stylelintResults) => {
     return message;
   }
 
-  let resultString = "";
-  stylelintResults
-    .forEach(fileResults => {
-      if(fileResults.errored) {
-        const testSuiteName = `stylelint: ${fileResults.source}`;
-        resultString += formatTeamCityMessage("testSuiteStarted", { name: testSuiteName });
-        fileResults.warnings.forEach(warning => {
-          const testName = `(${warning.line}, ${warning.column}) ${warning.text}`;
-          const testMessage = `[${warning.rule}] ${warning.text}`;
-          if(fileResults.ignored) {
-            resultString += formatTeamCityMessage("testIgnored", { name: testName, message: testMessage });
-          } else {
-            resultString += formatTeamCityMessage("testStarted", { name: testName });
-            if (warning.severity === "error") {
-              resultString += formatTeamCityMessage("testFailed", { name: testName, message: testMessage });
+  function getResultsAsTestFailures(lintingResults) {
+    let resultString = "";
+    lintingResults
+      .forEach(fileResults => {
+        if(fileResults.errored) {
+          const testSuiteName = `stylelint: ${fileResults.source}`;
+          resultString += formatTeamCityMessage("testSuiteStarted", { name: testSuiteName });
+          fileResults.warnings.forEach(warning => {
+            const testName = `(${warning.line}, ${warning.column}) ${warning.text}`;
+            const testMessage = `[${warning.rule}] ${warning.text}`;
+            if(fileResults.ignored) {
+              resultString += formatTeamCityMessage("testIgnored", { name: testName, message: testMessage });
+            } else {
+              resultString += formatTeamCityMessage("testStarted", { name: testName });
+              if(warning.severity === "error") {
+                resultString += formatTeamCityMessage("testFailed", { name: testName, message: testMessage });
+              }
+              resultString += formatTeamCityMessage("testFinished", { name: testName });
             }
-            resultString += formatTeamCityMessage("testFinished", { name: testName });
-          }
-        });
-        resultString += formatTeamCityMessage("testSuiteFinished", { name: testSuiteName });
-      }
-    });
+          });
+          resultString += formatTeamCityMessage("testSuiteFinished", { name: testSuiteName });
+        }
+      });
     return resultString;
+  }
+
+  function formatPath(path) {
+    return path
+      .replace(__dirname, "")
+      .substring(1)
+      .replace(/\\/g, "/");
+  }
+
+  function getResultsAsInspections(lintingResults) { 
+    let resultString = "";
+    const inspectionTypes = {};
+    const deprecations = "deprecations";
+    const invalidRuleOptions = "invalid-rule-options";
+    lintingResults
+      .forEach(fileResults => {
+        if(fileResults.errored) {
+          const sourceFile = formatPath(fileResults.source);
+          fileResults.warnings.forEach(warning => {
+            if(!inspectionTypes[warning.rule]) { 
+              inspectionTypes[warning.rule] = true;
+              resultString += formatTeamCityMessage("inspectionType", {
+                id: warning.rule,
+                name: warning.rule,
+                category: "Rule Violations",
+                description: `Stylelint ${warning.rule} rule violations`
+              });
+            }
+            const severity = fileResults.ignored ? "INFO" : warning.severity === "error" ? "ERROR" : "WARNING";
+            resultString += formatTeamCityMessage("inspection", {
+              typeId: warning.rule,
+              message: `line ${warning.line}, col ${warning.column}: ${warning.text}`,
+              file: sourceFile,
+              line: warning.line,
+              SEVERITY: severity
+            });
+          });
+          fileResults.deprecations.forEach(deprecation => {
+            if(!inspectionTypes[deprecations]) { 
+              inspectionTypes[deprecations] = true;
+              resultString += formatTeamCityMessage("inspectionType", {
+                id: deprecations,
+                name: deprecations,
+                category: "Deprecated Features",
+                description: "Features that will be removed in the next major version"
+              });
+            }
+            resultString += formatTeamCityMessage("inspection", {
+              typeId: deprecations,
+              message: `${deprecation.text} See more at ${deprecation.reference}`,
+              file: sourceFile,
+              SEVERITY: "WEAK WARNING"
+            });
+          });
+          fileResults.invalidOptionWarnings.forEach(warning => {
+            if(!inspectionTypes[invalidRuleOptions]) { 
+              inspectionTypes[invalidRuleOptions] = true;
+              resultString += formatTeamCityMessage("inspectionType", {
+                id: invalidRuleOptions,
+                name: invalidRuleOptions,
+                category: "Invalid Options",
+                description: "Invalid or unknown rule configuration options"
+              });
+            }
+            resultString += formatTeamCityMessage("inspection", {
+              typeId: invalidRuleOptions,
+              message: warning.text,
+              file: sourceFile,
+              SEVERITY: "ERROR"
+            });
+          });
+        }
+      });
+    return resultString;
+  }
+
+  function loadUserConfigFromPackageJson() {
+    try {
+      const packageJson = JSON.parse(fs.readFileSync("package.json"));
+      return packageJson["stylelint-teamcity-reporter"] || {};
+    } catch (e) {
+      console.warn("Unable to load config from package.json");
+      return {};
+    }
+  }
+
+  const config = loadUserConfigFromPackageJson();
+  const reporter = config.reporter || process.env.STYLELINT_TEAMCITY_REPORTER || "errors";
+
+  if (reporter === "inspections") { 
+    return getResultsAsInspections(stylelintResults);
+  }
+
+  return getResultsAsTestFailures(stylelintResults);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-teamcity-reporter",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "reporter"
   ],
   "author": "Brian Spencer",
+  "contributors": ["Marko Binic"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/bjspencer/stylelint-teamcity-reporter/issues"


### PR DESCRIPTION
Hello @interrobrian,

Firstly, sorry for sending this PR out of the blue, but this package has the right name and there's just too many of them for me to add another duplicate :) My team is going to start using stylelint with TeamCity in the following couple of weeks, so I wanted to give them the familiar experience they get with FxCop and ReSharper inspections.

The new style of reporting is opt-in, so everything should work the same unless explicitly configured. Looking forward to your feedback and hoping you merge and release it. Also, I'd be happy to maintain and support it if needed.

Cheers,
Marko