### PR TITLE
Add missing fs import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const fs = require("fs");
+
 module.exports = (stylelintResults) => {
   function tcEscape(message) {
     if(!message.replace) {


### PR DESCRIPTION
`fs.readFileSync` is used here https://github.com/interrobrian/stylelint-teamcity-reporter/blob/1697ac9712b512352831e3da4bfa9ecbd56c93a6/index.js#L129 but it is not imported anywhere.